### PR TITLE
dialyzer fixes: add .t to Decimal type

### DIFF
--- a/lib/math.ex
+++ b/lib/math.ex
@@ -38,7 +38,7 @@ defmodule Monetized.Math do
 
   """
 
-  @spec add(Money.t | String.t | integer | float | Decimal, Money.t | String.t | integer | float | Decimal) :: Money.t
+  @spec add(Money.t | String.t | integer | float | Decimal.t, Money.t | String.t | integer | float | Decimal.t) :: Money.t
 
   def add(a, b) do
     a = to_money(a)
@@ -77,7 +77,7 @@ defmodule Monetized.Math do
 
   """
 
-  @spec sub(Money.t | String.t | integer | float | Decimal, Money.t | String.t | integer | float | Decimal) :: Money.t
+  @spec sub(Money.t | String.t | integer | float | Decimal.t, Money.t | String.t | integer | float | Decimal.t) :: Money.t
 
   def sub(a, b) do
     a = to_money(a)

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -235,7 +235,7 @@ defmodule Monetized.Money do
 
   """
 
-  @spec make(integer | float | String.t | Decimal, list) :: t
+  @spec make(integer | float | String.t | Decimal.t, list) :: t
 
   def make(amount, options \\ []) do
     do_make(amount, options)
@@ -401,7 +401,7 @@ defmodule Monetized.Money do
 
   """
 
-  @spec from_decimal(Decimal, list) :: t
+  @spec from_decimal(Decimal.t, list) :: t
 
   def from_decimal(value = %Decimal{}, options \\ []) do
     currency_key = option_or_config(config(), options, :currency)


### PR DESCRIPTION
Without .t, Decimal alone just means a literal Decimal atom (:"Elixir.Decimal")